### PR TITLE
[#4] Implement custom type errors for IsMember

### DIFF
--- a/src/Data/WorldPeace/Union.hs
+++ b/src/Data/WorldPeace/Union.hs
@@ -135,13 +135,9 @@ type family RIndex (r :: k) (rs :: [k]) :: Nat where
 -- | Text of the error message.
 type NoElementError (r :: k) (rs :: [k]) =
           'Text "You require open sum type to contain the following element:"
-    ':$$: 'Text ""
     ':$$: 'Text "    " ':<>: 'ShowType r
-    ':$$: 'Text ""
     ':$$: 'Text "However, given list can store elements only of the following types:"
-    ':$$: 'Text ""
     ':$$: 'Text "    " ':<>: 'ShowType rs
-    ':$$: 'Text ""
 
 -- | This type family checks whether @a@ is inside @as@ and produces
 -- compile-time error if not.
@@ -618,6 +614,8 @@ unionHandle unionHandler aHandler u =
 ---------------
 
 -- | We can use @'Union' 'Identity'@ as a standard open sum type.
+--
+-- See the documentation for 'Union'.
 type OpenUnion = Union Identity
 
 -- | Case analysis for 'OpenUnion'.
@@ -677,11 +675,25 @@ openUnionPrism = unionPrism . iso runIdentity Identity
 
 -- | Just like 'unionLift' but for 'OpenUnion'.
 --
+-- ==== __Examples__
+--
 -- Creating an 'OpenUnion':
 --
 -- >>> let string = "hello" :: String
 -- >>> openUnionLift string :: OpenUnion '[Double, String, Int]
 -- Identity "hello"
+--
+-- You will get a compile error if you try to create an 'OpenUnion' that
+-- doesn't contain the type:
+--
+-- >>> let float = 3.5 :: Float
+-- >>> openUnionLift float :: OpenUnion '[Double, Int]
+-- ...
+--     • You require open sum type to contain the following element:
+--           Float
+--       However, given list can store elements only of the following types:
+--           '[Double, Int]
+-- ...
 openUnionLift
   :: forall a as.
      IsMember a as
@@ -705,6 +717,18 @@ openUnionLift = review openUnionPrism
 -- >>> let p = openUnionLift double :: OpenUnion '[Double, String]
 -- >>> openUnionMatch p :: Maybe String
 -- Nothing
+--
+-- You will get a compile error if you try to pull out an element from
+-- the 'OpenUnion' that doesn't exist within it.
+--
+-- >>> let o2 = openUnionLift double :: OpenUnion '[Double, Char]
+-- >>> openUnionMatch o2 :: Maybe Float
+-- ...
+--     • You require open sum type to contain the following element:
+--           Float
+--       However, given list can store elements only of the following types:
+--           '[Double, Char]
+-- ...
 openUnionMatch
   :: forall a as.
      IsMember a as

--- a/test/Test/TypeErrors.hs
+++ b/test/Test/TypeErrors.hs
@@ -26,18 +26,22 @@ unionRemoveTypeErrors =
         let u = This (Identity "hello") :: Union Identity '[String]
         shouldNotTypecheck
           (unionRemove u :: Either (Union Identity '[]) (Identity Double))
+
     , testCase "too few types in resulting union 2" $ do
         let u = This (Identity "hello") :: Union Identity '[String, Char, Double]
         shouldNotTypecheck
           (unionRemove u :: Either (Union Identity '[String]) (Identity Double))
+
     , testCase "too many types in resulting union 1" $ do
         let u = This (Identity "hello") :: Union Identity '[String]
         shouldNotTypecheck
           (unionRemove u :: Either (Union Identity '[String, String]) (Identity Double))
+
     , testCase "too many types in resulting union 2" $ do
         let u = This (Identity "hello") :: Union Identity '[String, Char, Double]
         shouldNotTypecheck
           (unionRemove u :: Either (Union Identity '[String, Char, Double]) (Identity Double))
+
     , testCase "does not pull out multiple" $ do
         let u = This (Identity "hello") :: Union Identity '[String, String, Double]
         shouldNotTypecheck


### PR DESCRIPTION
Resolves #4

I was testing this on the following example:

```haskell
data UrlParseException = UrlParseException
data FileNotFound = FileNotFound
data DatabaseError = DatabaseError
data RequestLimitError = RequestLimitError

unionExample :: OpenUnion '[ FileNotFound, DatabaseError, RequestLimitError ]
unionExample = openUnionLift FileNotFound

parseException :: Maybe UrlParseException
parseException = openUnionMatch unionExample
```

**Error message before:**

```
    • No instance for (Data.WorldPeace.Union.UElem
                         UrlParseException
                         '[]
                         (Data.WorldPeace.Union.RIndex UrlParseException '[]))
        arising from a use of ‘openUnionMatch’
```

**Error message after:**

```
    • You require open sum type to contain the following element:
      
          UrlParseException
      
      However, given list can store elements only of the following types:
      
          '[FileNotFound, DatabaseError, RequestLimitError]   
```

Feel free to change text message or name of some helper type families :slightly_smiling_face: 